### PR TITLE
Fixed import for older UUID's stored by ProxySuite without dashes

### DIFF
--- a/src/main/java/fi/matiaspaavilainen/masuiteconverter/ProxySuite.java
+++ b/src/main/java/fi/matiaspaavilainen/masuiteconverter/ProxySuite.java
@@ -256,7 +256,11 @@ public class ProxySuite {
             rs = statement.executeQuery();
             while (rs.next()) {
                 MaSuitePlayer msp = new MaSuitePlayer();
-                msp.setUniqueId(UUID.fromString(rs.getString("uuid")));
+                String uuid = rs.getString("uuid");
+                if(uuid.length() == 32) {
+                    uuid = uuid.substring(0,8) + "-" + uuid.substring(8, 12) + "-" + uuid.substring(12, 16) + "-" + uuid.substring(16, 20) + "-" + uuid.substring(20);
+                }
+                msp.setUniqueId(UUID.fromString(uuid));
                 msp.setUsername(rs.getString("name"));
                 msp.setNickname(null);
                 LocalDate firstJoin = rs.getDate("first_join").toLocalDate();


### PR DESCRIPTION
While trying to import our ProxySuite data it glitched out while trying to import UUIDs. Upon further investigation it looked like some of our UUIDs were stored without dashes, breaking the plugin. This pull request fixes that.